### PR TITLE
Bugfix: Memory usage climbed to 1GB

### DIFF
--- a/SearchOverflow.xcodeproj/project.pbxproj
+++ b/SearchOverflow.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		BA6BF15022A8B8850067D42A /* Pageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6BF14F22A8B8850067D42A /* Pageable.swift */; };
 		BA6BF15222A8CA7D0067D42A /* QuestionDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6BF15122A8CA7D0067D42A /* QuestionDataController.swift */; };
 		BA6BF15422A8ED8B0067D42A /* QuestionDataControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6BF15322A8ED8B0067D42A /* QuestionDataControllerTests.swift */; };
+		BA6BF15622A96C800067D42A /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6BF15522A96C800067D42A /* Array+Extension.swift */; };
 		BABBB33622A73ACC00BFAD9B /* QuestionDetailsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBB33522A73ACC00BFAD9B /* QuestionDetailsCoordinator.swift */; };
 		BABBB33822A7904900BFAD9B /* QuestionDetailsPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBB33722A7904900BFAD9B /* QuestionDetailsPageViewController.swift */; };
 		BABBB33A22A7922900BFAD9B /* AnswersTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBB33922A7922900BFAD9B /* AnswersTableViewController.swift */; };
@@ -145,6 +146,7 @@
 		BA6BF14F22A8B8850067D42A /* Pageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pageable.swift; sourceTree = "<group>"; };
 		BA6BF15122A8CA7D0067D42A /* QuestionDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDataController.swift; sourceTree = "<group>"; };
 		BA6BF15322A8ED8B0067D42A /* QuestionDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDataControllerTests.swift; sourceTree = "<group>"; };
+		BA6BF15522A96C800067D42A /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
 		BABBB33522A73ACC00BFAD9B /* QuestionDetailsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDetailsCoordinator.swift; sourceTree = "<group>"; };
 		BABBB33722A7904900BFAD9B /* QuestionDetailsPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDetailsPageViewController.swift; sourceTree = "<group>"; };
 		BABBB33922A7922900BFAD9B /* AnswersTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswersTableViewController.swift; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 				5D5F8CC221EB326B007905A6 /* UIColor+Extension.swift */,
 				5D5F8CC821EB3C60007905A6 /* UIFont+Extension.swift */,
 				BA566DC6226ED0FE005F247C /* UIView+Extension.swift */,
+				BA6BF15522A96C800067D42A /* Array+Extension.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -730,6 +733,7 @@
 				BA0474EF21F06EBC0029983E /* BaseDataController.swift in Sources */,
 				5D5F8C9721E96907007905A6 /* Answer.swift in Sources */,
 				BABBB33822A7904900BFAD9B /* QuestionDetailsPageViewController.swift in Sources */,
+				BA6BF15622A96C800067D42A /* Array+Extension.swift in Sources */,
 				BA0474F321F0DC840029983E /* Home+DataController.swift in Sources */,
 				5D5F8C6B21E87DF5007905A6 /* AppDelegate.swift in Sources */,
 				5D5F8C9321E88251007905A6 /* StackOverflow.swift in Sources */,

--- a/SearchOverflow/Data/API/StackOverflow.swift
+++ b/SearchOverflow/Data/API/StackOverflow.swift
@@ -15,10 +15,11 @@ private let baseURL = "https://api.stackexchange.com"
  * it is not necessary (or advisable) to create filters at runtime.
  */
 
+private let shallowQuestionFilter = "&filter=!-MOiNm42tgzzkEU(LzVlBT1xkCHN-0O_A"
+private let filterParam = "&filter=!)s))yOCJcBsc9uLD71Rm"
+
 /// StackOverflow API Endpoint
 enum StackOverflow {
-    static let filterParam = "&filter=!)s))yOCJcBsc9uLD71Rm"
-
     case category(_ category: QuestionCategory, page: Int)
     case search(for: String, page: Int)
     case question(id: Int)
@@ -26,7 +27,7 @@ enum StackOverflow {
 
 extension StackOverflow: EndPoint {
     var baseURL: URL {
-        guard let url = URL(string: "https://api.stackexchange.com/2.2/" + path + StackOverflow.filterParam)
+        guard let url = URL(string: "https://api.stackexchange.com/2.2/")
             else { fatalError("Base url could not be configured.") }
 
         return url
@@ -40,10 +41,10 @@ extension StackOverflow: EndPoint {
             case .featured: categoryString = "featured"
             case .noAnswers: categoryString = "no-answers"
             case .unanswered: categoryString = "unanswered"
-            case .top: return "questions?page=\(page)&order=desc&sort=votes&site=stackoverflow"
+            case .top: return "questions?page=\(page)&order=desc&sort=votes&site=stackoverflow" + shallowQuestionFilter
             }
         
-            return "questions/" + categoryString + "?page=\(page)&order=desc&sort=activity&site=stackoverflow"
+            return "questions/" + categoryString + "?page=\(page)&order=desc&sort=activity&site=stackoverflow" + shallowQuestionFilter
     
         case .search(let text, let page):
             guard let textPercentEncoded = text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {

--- a/SearchOverflow/Data/API/StackOverflow.swift
+++ b/SearchOverflow/Data/API/StackOverflow.swift
@@ -16,7 +16,7 @@ private let baseURL = "https://api.stackexchange.com"
  */
 
 private let shallowQuestionFilter = "&filter=!-MOiNm42tgzzkEU(LzVlBT1xkCHN-0O_A"
-private let filterParam = "&filter=!)s))yOCJcBsc9uLD71Rm"
+private let questionFilter = "&filter=!)s))yOCJcBsc9uLD71Rm"
 
 /// StackOverflow API Endpoint
 enum StackOverflow {
@@ -41,10 +41,10 @@ extension StackOverflow: EndPoint {
             case .featured: categoryString = "featured"
             case .noAnswers: categoryString = "no-answers"
             case .unanswered: categoryString = "unanswered"
-            case .top: return "questions?page=\(page)&order=desc&sort=votes&site=stackoverflow" + shallowQuestionFilter
+            case .top: return "questions?page=\(page)&order=desc&sort=votes&site=stackoverflow" + questionFilter
             }
         
-            return "questions/" + categoryString + "?page=\(page)&order=desc&sort=activity&site=stackoverflow" + shallowQuestionFilter
+            return "questions/" + categoryString + "?page=\(page)&order=desc&sort=activity&site=stackoverflow" + questionFilter
     
         case .search(let text, let page):
             guard let textPercentEncoded = text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {

--- a/SearchOverflow/Data/API/StackOverflow.swift
+++ b/SearchOverflow/Data/API/StackOverflow.swift
@@ -15,8 +15,8 @@ private let baseURL = "https://api.stackexchange.com"
  * it is not necessary (or advisable) to create filters at runtime.
  */
 
-private let shallowQuestionFilter = "&filter=!-MOiNm42tgzzkEU(LzVlBT1xkCHN-0O_A"
-private let questionFilter = "&filter=!)s))yOCJcBsc9uLD71Rm"
+let shallowQuestionFilter = "&filter=!-MOiNm42tgzzkEU(LzVlBT1xkCHN-0O_A"
+let questionFilter = "&filter=!)s))yOCJcBsc9uLD71Rm"
 
 /// StackOverflow API Endpoint
 enum StackOverflow {
@@ -50,10 +50,10 @@ extension StackOverflow: EndPoint {
             guard let textPercentEncoded = text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
                 fatalError("Could not percent encode searched for text.")
             }
-            return "search?page=\(page)&order=desc&sort=votes&intitle=\(textPercentEncoded)&site=stackoverflow"
+            return "search?page=\(page)&order=desc&sort=votes&intitle=\(textPercentEncoded)&site=stackoverflow" + questionFilter
 
         case .question(let id):
-            return "questions/\(id)?order=desc&sort=activity&site=stackoverflow"
+            return "questions/\(id)?order=desc&sort=activity&site=stackoverflow" + questionFilter
         }
     }
 }

--- a/SearchOverflow/Data/API/StackOverflowResponse.swift
+++ b/SearchOverflow/Data/API/StackOverflowResponse.swift
@@ -31,7 +31,7 @@ protocol StackOverflowResponseItem {
 
 // https://api.stackexchange.com/docs/wrapper
 /// The StackOverflow response item represents the response wrapper from the StackExchange API
-class StackOverflowResponse<SOR: StackOverflowItem>: StackOverflowResponseItem, Decodable {
+struct StackOverflowResponse<SOR: StackOverflowItem>: StackOverflowResponseItem, Decodable {
     typealias Item = SOR
     var hasMore: Bool
     var page: Int

--- a/SearchOverflow/Data/Controllers/Pageable.swift
+++ b/SearchOverflow/Data/Controllers/Pageable.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol Pageable {
     var totalItems: Int { get }
     var pageSize: Int { get }
+    var maxNumberOfPages: Int { get set }
 }
 
 extension Pageable {
@@ -25,6 +26,6 @@ extension Pageable {
         }
         else { pages = 0}
         
-        return pages
+        return pages > maxNumberOfPages ? maxNumberOfPages : pages
     }
 }

--- a/SearchOverflow/Data/Controllers/QuestionDataController.swift
+++ b/SearchOverflow/Data/Controllers/QuestionDataController.swift
@@ -42,7 +42,8 @@ class QuestionDataController: BaseDataController, Pageable {
 
     private(set) var totalItems: Int = 0
     private(set) var pageSize: Int = 0
-    
+    var maxNumberOfPages = 10
+
     private(set) var pagesLoading: [Int] = []
     private(set) var responseItems: [StackOverflowResponse<Question>] = []
 

--- a/SearchOverflow/Data/Controllers/QuestionDataController.swift
+++ b/SearchOverflow/Data/Controllers/QuestionDataController.swift
@@ -43,11 +43,27 @@ class QuestionDataController: BaseDataController, Pageable {
     private(set) var totalItems: Int = 0
     private(set) var pageSize: Int = 0
     
+    private(set) var responseItems: [StackOverflowResponse<Question>] = []
+
     // MARK: Lifecycle
     init(with router: Router) {
         self.router = router
     }
     
+    func appendResponseItem(_ item: StackOverflowResponse<Question>) {
+        // First try replacing the first occurance of this page
+        for (index, arrayItem) in responseItems.enumerated() {
+            if item.page == arrayItem.page {
+                responseItems[index] = item
+                return
+            }
+        }
+        
+        // Otherwise, append item and sort on page
+        responseItems.append(item)
+        responseItems.sort(by: { $0.page < $1.page })
+    }
+
     func handleQuestionDataResponse(_ response: HTTPURLResponse, data: Data?, page: Int) {
         // Handle the network response, parse data, and call completion
         switch self.handleNetworkResponse(response) ?? Result.failure("") {

--- a/SearchOverflow/Networking/NetworkRouter.swift
+++ b/SearchOverflow/Networking/NetworkRouter.swift
@@ -31,7 +31,7 @@ class NetworkRouter: Router {
 
     // Request builder
     private func buildRequest(from route: EndPoint) -> URLRequest {
-        var request = URLRequest(url: route.baseURL,
+        var request = URLRequest(url: route.url,
                                  cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
                                  timeoutInterval: 10.0)
 

--- a/SearchOverflow/Networking/Protocols/EndPoint.swift
+++ b/SearchOverflow/Networking/Protocols/EndPoint.swift
@@ -13,3 +13,9 @@ protocol EndPoint {
     var baseURL: URL { get }
     var path: String { get }
 }
+
+extension EndPoint {
+    var url: URL {
+        return URL(string: baseURL.absoluteString + path)!
+    }
+}

--- a/SearchOverflow/Utils/Array+Extension.swift
+++ b/SearchOverflow/Utils/Array+Extension.swift
@@ -1,0 +1,25 @@
+//
+//  Array+Extension.swift
+//  SearchOverflow
+//
+//  Created by Seth Folley on 6/6/19.
+//  Copyright © 2019 Seth Folley. All rights reserved.
+//
+
+import Foundation
+extension Array where Element: Equatable {
+    func removingDuplicates() -> [Element] {
+        var uniqueArray: [Element] = []
+        forEach { element in
+            if !uniqueArray.contains(element) {
+                uniqueArray.append(element)
+            }
+        }
+        
+        return uniqueArray
+    }
+    
+    mutating func removeDuplicates() {
+        self = removingDuplicates()
+    }
+}

--- a/SearchOverflow/View Controllers/Home/Home+DataController.swift
+++ b/SearchOverflow/View Controllers/Home/Home+DataController.swift
@@ -11,9 +11,6 @@ import Foundation
 extension HomeViewController {
     func questionsBeganLoading() {
         DispatchQueue.main.async {
-            // reset table data
-            self.questionPages = []
-            
             self.resultsTableView?.reloadData()
             self.resultsTableView?.isHidden = true
             
@@ -48,16 +45,6 @@ extension HomeViewController: QuestionDataControllerDelegate {
     }
     
     func didReceiveQuestions(_ questions: [Question], forPage page: Int) {
-        // fill the array if needed
-        if questionPages.isEmpty, let pages = questionDataController?.numberOfPages {
-            questionPages = Array<[Question]>(repeating: [], count: pages)
-        }
-        
-        if questionDataController?.numberOfPages != 0 {
-            let questionsSorted = questions.sorted(by: { $0.score > $1.score })
-            questionPages[page - 1] = questionsSorted
-        }
-        
         // Reload the table if this is the first page
         if page == 1 {
             firstPageLoaded(with: questions)

--- a/SearchOverflow/View Controllers/Home/HomeViewController.swift
+++ b/SearchOverflow/View Controllers/Home/HomeViewController.swift
@@ -46,8 +46,6 @@ class HomeViewController: BaseViewController {
             questionDataController?.delegate = self
         }
     }
-    
-    var questionPages: [[Question]] = []
 
     // MARK: - Lifecycle
     override func viewDidLoad() {

--- a/SearchOverflow/View Controllers/Home/HomeViewController.swift
+++ b/SearchOverflow/View Controllers/Home/HomeViewController.swift
@@ -60,6 +60,15 @@ class HomeViewController: BaseViewController {
         questionDataController?.beginLoading(category: .featured)
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        // remove table view selection
+        if let indexes = resultsTableView?.indexPathsForSelectedRows {
+            indexes.forEach({ resultsTableView?.deselectRow(at: $0, animated: false) })
+        }
+    }
+
     private func setupNavigationBar() {
         categoryNavButton.sizeToFit()
         navigationItem.titleView = categoryNavButton

--- a/SearchOverflowTests/Data/API/StackOverflowURLBuilderTests.swift
+++ b/SearchOverflowTests/Data/API/StackOverflowURLBuilderTests.swift
@@ -11,16 +11,16 @@ import XCTest
 
 class StackOverflowURLBuilderTests: XCTestCase {
 
-    let searchUrl = URL(string: "https://api.stackexchange.com/2.2/search?page=1&order=desc&sort=votes&intitle=chicken&site=stackoverflow\(StackOverflow.filterParam)")!
-    let questionUrl = URL(string: "https://api.stackexchange.com/2.2/questions/1?order=desc&sort=activity&site=stackoverflow\(StackOverflow.filterParam)")!
+    let searchUrl = URL(string: "https://api.stackexchange.com/2.2/search?page=1&order=desc&sort=votes&intitle=chicken&site=stackoverflow\(questionFilter)")!
+    let questionUrl = URL(string: "https://api.stackexchange.com/2.2/questions/1?order=desc&sort=activity&site=stackoverflow\(questionFilter)")!
 
     func test_SearchBaseUrl() {
-        let url = StackOverflow.search(for: "chicken", page: 1).baseURL
+        let url = StackOverflow.search(for: "chicken", page: 1).url
         XCTAssertEqual(url, searchUrl)
     }
     
     func test_QuestionBaseUrl() {
-        let url = StackOverflow.question(id: 1).baseURL
+        let url = StackOverflow.question(id: 1).url
         XCTAssertEqual(url, questionUrl)
     }
 }

--- a/SearchOverflowTests/Data/Controllers/QuestionDataControllerTests.swift
+++ b/SearchOverflowTests/Data/Controllers/QuestionDataControllerTests.swift
@@ -43,7 +43,32 @@ class SearchControllerTests: XCTestCase, QuestionDataControllerDelegate {
         
         router.requestedPage = 1
     }
-    
+    // MARK: Helpers
+    func test_QDC_AppendResponseItems() {
+        // Test we append items
+        let firstMockResp = StackOverflowResponse<Question>(hasMore: true, page: 1, pageSize: 30, total: 300,
+                                                            type: .question, items: [],
+                                                            errorId: nil, errorName: nil, errorMessage: nil)
+        sut.appendResponseItem(firstMockResp)
+        XCTAssertFalse(sut.responseItems.isEmpty)
+        
+        // Test the items are sorted by page asc
+        let secondMock = StackOverflowResponse<Question>(hasMore: true, page: 2, pageSize: 30, total: 300,
+                                                         type: .question, items: [],
+                                                         errorId: nil, errorName: nil, errorMessage: nil)
+        sut.appendResponseItem(secondMock)
+        XCTAssert(sut.responseItems.last?.page == 2)
+        
+        // Test the replace functionality
+        let thirdMock = StackOverflowResponse<Question>(hasMore: true, page: 2, pageSize: 15, total: 300,
+                                                        type: .question, items: [],
+                                                        errorId: nil, errorName: nil, errorMessage: nil)
+        sut.appendResponseItem(thirdMock)
+        XCTAssert(sut.responseItems.count == 2)
+        XCTAssert(sut.responseItems.last?.pageSize == 15)
+    }
+
+    // MARK: Search
     func test_Search_CurrentSearchStringIsExpected() {
         sut.beginSearch(for: searchString)
         

--- a/SearchOverflowTests/Networking/NetworkRouterTests.swift
+++ b/SearchOverflowTests/Networking/NetworkRouterTests.swift
@@ -74,7 +74,7 @@ private let mockBaseURL = "https://www.reddit.com"
 private let mockPath = "/r/AustralianShepherd/"
 
 struct MockEndPoint: EndPoint {
-    var baseURL: URL = URL(string: mockBaseURL + mockPath)!
+    var baseURL: URL = URL(string: mockBaseURL)!
     var path: String = mockPath
 }
 

--- a/SearchOverflowTests/Utils/ExtensionsTests.swift
+++ b/SearchOverflowTests/Utils/ExtensionsTests.swift
@@ -27,4 +27,14 @@ class ExtensionsTests: XCTestCase {
     func test_Font_PrintsAll() {
         UIFont.printAvailableFonts()
     }
+    
+    func test_Array_RemovesDuplicates() {
+        var intArr = [1, 2, 2, 3, 4, 4, 4, 4]
+
+        let newSize = intArr.removingDuplicates().count
+        XCTAssert(newSize == 4)
+        
+        intArr.removeDuplicates()
+        XCTAssert(intArr.count == 4)
+    }
 }


### PR DESCRIPTION
There was an issue where the tableview was being informed there were 10s of thousands of sections, which caused the memory to spike. En route to fix this, I've brought the response item to the data controller and changed the way the tableview's data is being loaded. I also added a max number of pages (default to 10).